### PR TITLE
feat

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -101,15 +101,13 @@
     <br>
     <fl-switch v-model="model.active" activeColor="red" inActiveColor="black"></fl-switch>
     <fl-upload></fl-upload>
-      <!-- ***********dialog********* -->
-    <fl-button type="primary" @click="visible=true">点击打开 dialog</fl-button>
-    <fl-dialog :visible="visible" @close="close">
+    <fl-button type="primary" @click="visible=true">点击打开 Modal</fl-button>
+    <fl-modal :visible="visible" @close="close">
       <template #footer>
         <fl-button plain @click="visible=false">取消</fl-button>
         <fl-button type="primary" @click="visible=false">确定</fl-button>
       </template>
-    </fl-dialog>
-  <!-- ***********dialog********* -->
+    </fl-modal>
   </div>
 </template>
 

--- a/src/components/modal.vue
+++ b/src/components/modal.vue
@@ -1,19 +1,19 @@
 <template>
-<transition name="dialog-fade">
-  <div class="fl-dialog_wrapper" v-show="visible" @click.self="handleClose">
-    <div class="fl-dialog" :style="{width, marginTop: top}">
-      <div class="fl-dialog_header">
+<transition name="modal-fade">
+  <div class="fl-modal_wrapper" v-show="visible" @click.self="handleCloseWrapper">
+    <div class="fl-modal" :style="{width, marginTop: top}">
+      <div class="fl-modal_header">
         <slot name="title">
-            <span class="fl-dialog_title">{{title}}</span>
+            <span class="fl-modal_title">{{title}}</span>
         </slot>
-        <button class="fl-dialog_headerbtn" @click="handleClose">x</button>
+        <button class="fl-modal_headerbtn" @click="handleClose">x</button>
       </div>
-      <div class="fl-dialog_body">
+      <div class="fl-modal_body">
         <slot>
-            <span>这一段信息</span>
+            <span>这是一段信息</span>
         </slot>
       </div>
-      <div class="fl-dialog_footer" v-if="$slots.footer">
+      <div class="fl-modal_footer" v-if="$slots.footer">
         <slot name="footer">
          <fl-button plain>取消</fl-button>
          <fl-button type="primary">确定</fl-button>
@@ -26,7 +26,7 @@
 
 <script>
 export default {
-  name: 'FlDialog',
+  name: 'FlModal',
   props: {
     title: {
       type: String,
@@ -43,18 +43,33 @@ export default {
     visible: {
       type: Boolean,
       default: false
+    },
+    closeWrapper: {
+      type: String,
+      default: 'false'
     }
   },
   methods: {
     handleClose () {
       this.$emit('close', false)
+    },
+    handleCloseWrapper () {
+      if (this.closeWrapper === 'false') {
+        const content = document.querySelector('.fl-modal')
+        content.classList.add('shakeClass')
+        setTimeout(() => {
+          content.classList.remove('shakeClass')
+        }, 400)
+      } else {
+        this.$emit('close', false)
+      }
     }
   }
 }
 </script>
 
 <style lang="scss" scoped>
-.fl-dialog_wrapper {
+.fl-modal_wrapper {
   position: fixed;
   top: 0;
   right: 0;
@@ -65,7 +80,7 @@ export default {
   z-index: 999;
   background-color: rgba(0, 0, 0, 0.5);
 
-  .fl-dialog {
+  .fl-modal {
     position: relative;
     margin: 15vh auto 50px;
     background-color: #fff;
@@ -76,12 +91,12 @@ export default {
 
     &_header {
       padding: 20px 20px 10px;
-      .fl-dialog_title {
+      .fl-modal_title {
         line-height: 24px;
         font-size: 18px;
         color: gray;
       }
-      .fl-dialog_headerbtn {
+      .fl-modal_headerbtn {
         position: absolute;
         top: 20px;
         right: 20px;
@@ -109,11 +124,10 @@ export default {
     }
   }
 }
-.dialog-fade-enter-active {
+.modal-fade-enter-active {
   animation: fade .3s;
 }
-
-.dialog-fade-leave-active {
+.modal-fade-leave-active {
   animation: fade .3s reverse;
 }
 @keyframes fade {
@@ -124,6 +138,20 @@ export default {
   100% {
     opacity: 1;
     transform:  translateY(0px);
+  }
+}
+.shakeClass{
+  animation: shake .3s infinite;
+}
+@keyframes shake {
+  0% {
+    transform: translateX(-10px);
+  }
+  50% {
+    transform: translateX(5px);
+  }
+  100% {
+    transform: translateX(0);
   }
 }
 </style>

--- a/src/main.js
+++ b/src/main.js
@@ -11,7 +11,7 @@ import FlRadioGroup from './components/radio-group.vue'
 import FlForm from './components/form.vue'
 import FlFormItem from './components/form-item.vue'
 import FlSwitch from './components/switch.vue'
-import FlDialog from './components/dialog.vue'
+import FlModal from './components/modal.vue'
 import FlUpload from './components/upload.vue'
 import FlCheckbox from './components/checkbox.vue'
 import FlCheckboxGroup from './components/checkbox-group.vue'
@@ -29,7 +29,7 @@ app.component(FlRadioGroup.name, FlRadioGroup)
 app.component(FlForm.name, FlForm)
 app.component(FlFormItem.name, FlFormItem)
 app.component(FlSwitch.name, FlSwitch)
-app.component(FlDialog.name, FlDialog)
+app.component(FlModal.name, FlModal)
 app.component(FlUpload.name, FlUpload)
 app.component(FlCheckbox.name, FlCheckbox)
 app.component(FlCheckboxGroup.name, FlCheckboxGroup)


### PR DESCRIPTION
用‘modal’替换‘dialog’
新增可传入参数closeWrapper，默认为false，点击模态框内容以外的区域不可直接关闭模态框；修改为true即可直接关闭